### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,14 +30,7 @@
         "Vue.js reporting tool",
         "React.js reporting tool"
     ],
-    "dependencies": {
-        "svg2img": "^1.0.0-beta.2",
-        "jimp-compact": "^0.16.1-2",
-        "sync-request": "^6.1.0",
-        "node-machine-id": "^1.1.12",
-        "xmldoc": "^1.2.0",
-        "stimulsoft-data-adapter": "2024.2.4"
-    },
+    "dependencies": {},
     "files": [
         "THIRD-PARTY.md",
         "LICENSE.md",


### PR DESCRIPTION
No  dependencies any more,  because they are no use, all codes has been compiled. But when we use this `stimulsoft-reports-js` in `package.json` it will download a lot of useless codes when we run `npm install` , this is awful !